### PR TITLE
Changed test to 2004/12/30

### DIFF
--- a/tests/pecan64.biocro.xml
+++ b/tests/pecan64.biocro.xml
@@ -47,7 +47,7 @@
       </met>
     </inputs>
       <start.date>2004/01/01</start.date>
-      <end.date>2004/12/31</end.date>
+      <end.date>2004/12/30</end.date>
     <host>
       <name>localhost</name>
     </host>


### PR DESCRIPTION
Fixed problem w/ leap year

I suspect that it may be an issue with time zone rather than with leap year. In any case, it is okay to always ignore leap years, e.g. by trimming the extra day from the met input.