### PR TITLE
Ensure docs are complete and correct with respect to SEVERE vs ERROR

### DIFF
--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -247,7 +247,7 @@ logger.getLevelNumber <- function(level) {
 ##' `logger.getLevel()` is not required to restore the level after a 
 ##' temporary change.
 ##'
-##' @return level the level of the message, one of 
+##' @return A string giving the lowest message level that will be reported, one of 
 ##' "ALL", "DEBUG", "INFO", "WARN", "ERROR", "SEVERE", or "OFF".
 ##' @export
 ##' @author Rob Kooper

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -181,8 +181,6 @@ logger.message <- function(level, msg, ..., wrap = TRUE) {
 ##'
 ##' @param level the level of the message. One of "ALL", "DEBUG", "INFO", "WARN",
 ##' "ERROR", "SEVERE", or "OFF".
-##' Use "SEVERE" instead of "ERROR" for fatal errors. If `logger.setQuitOnSevere(TRUE)`,
-##' These will the program to stop (default is FALSE). 
 ##'
 ##' @export
 ##' @return When logger level is set, the previous level is returned invisibly.

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -174,6 +174,11 @@ logger.message <- function(level, msg, ..., wrap = TRUE) {
 ##' This will configure the logger level. This allows to turn DEBUG, INFO,
 ##' WARN, ERROR, and SEVERE messages on and off.
 ##'
+##' Note that this controls _printing_ of messages and does not change other behavior.
+##' In particular, suppressing SEVERE by setting the level to "OFF" does not prevent
+##' logger.severe() from signaling an error (and terminating the program if 
+##' `logger.setQuitOnSevere(TRUE)`).
+##'
 ##' @param level the level of the message. One of "ALL", "DEBUG", "INFO", "WARN",
 ##' "ERROR", "SEVERE", or "OFF".
 ##' Use "SEVERE" instead of "ERROR" for fatal errors. If `logger.setQuitOnSevere(TRUE)`,

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -214,6 +214,7 @@ logger.setLevel <- function(level) {
 ##
 ## SEVERE is treated as more serious than ERROR,
 ## and will terminate the session if `logger.setQuitOnSevere(TRUE)`
+## or call stop() otherwise
 ##
 ## @return level the level of the message
 ## @author Rob Kooper

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -81,7 +81,7 @@ logger.error <- function(msg, ...) {
 ##' This function will print a message and stop execution of the code. This
 ##' should only be used if the application should terminate.
 ##'
-##' set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
+##' Set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
 ##' the session. This is set by default to TRUE if interactive or running
 ##' inside Rstudio.
 ##'
@@ -173,9 +173,13 @@ logger.message <- function(level, msg, ..., wrap = TRUE) {
 ##' Configure logging level.
 ##'
 ##' This will configure the logger level. This allows to turn DEBUG, INFO,
-##' WARN and ERROR messages on and off.
+##' WARN, ERROR, and SEVERE messages on and off.
 ##'
-##' @param level the level of the message (ALL, DEBUG, INFO, WARN, ERROR, OFF)
+##' @param level the level of the message. One of "ALL", "DEBUG", "INFO", "WARN",
+##' "ERROR", "SEVERE", or "OFF".
+##' Use "SEVERE" instead of "ERROR" for fatal errors. If `logger.setQuitOnSevere(TRUE)`,
+##' These will the program to stop (default is FALSE). 
+##'
 ##' @export
 ##' @return When logger level is set, the previous level is returned invisibly.
 ##'   This can be passed to `logger.setLevel()` to restore the previous level.
@@ -183,6 +187,11 @@ logger.message <- function(level, msg, ..., wrap = TRUE) {
 ##' @examples
 ##' \dontrun{
 ##' logger.setLevel('DEBUG')
+##' 
+##' # Temporarily turn logger off
+##' old_logger_level <- logger.setLevel("OFF")
+##'   # code here
+##' logger.setLevel(old_logger_level)
 ##' }
 logger.setLevel <- function(level) {
   original_level <- logger.getLevel()
@@ -193,14 +202,21 @@ logger.setLevel <- function(level) {
 
 
 ## Given the string representation this will return the numeric value
-## DEBUG = 10
-## INFO  = 20
-## WARN  = 30
-## ERROR = 40
-## ALL   = 99
 ##
-##@return level the level of the message
-##@author Rob Kooper
+## Supported levels
+##   ALL    = 0
+##   DEBUG  = 10
+##   INFO   = 20
+##   WARN   = 30
+##   ERROR  = 40
+##   SEVERE = 50
+##   OFF    = 60
+##
+## SEVERE is treated as more serious than ERROR,
+## and will terminate the session if `logger.setQuitOnSevere(TRUE)`
+##
+## @return level the level of the message
+## @author Rob Kooper
 logger.getLevelNumber <- function(level) {
   if (toupper(level) == "ALL") {
     return(0)
@@ -213,7 +229,7 @@ logger.getLevelNumber <- function(level) {
   } else if (toupper(level) == "ERROR") {
     return(40)
   } else if (toupper(level) == "SEVERE") {
-    return(40)
+    return(50)
   } else if (toupper(level) == "OFF") {
     return(60)
   } else {
@@ -225,9 +241,14 @@ logger.getLevelNumber <- function(level) {
 
 ##' Get configured logging level.
 ##'
-##' This will return the current level configured of the logging messages
+##' This will return the current level configured of the logging messages.
+##' 
+##' Note that `logger.setLevel()` invisibly returns current level, so 
+##' `logger.getLevel()` is not required to restore the level after a 
+##' temporary change.
 ##'
-##' @return level the level of the message (ALL, DEBUG, INFO, WARN, ERROR, OFF)
+##' @return level the level of the message, one of 
+##' "ALL", "DEBUG", "INFO", "WARN", "ERROR", "SEVERE", or "OFF".
 ##' @export
 ##' @author Rob Kooper
 ##' @examples

--- a/base/logger/R/logger.R
+++ b/base/logger/R/logger.R
@@ -82,8 +82,7 @@ logger.error <- function(msg, ...) {
 ##' should only be used if the application should terminate.
 ##'
 ##' Set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
-##' the session. This is set by default to TRUE if interactive or running
-##' inside Rstudio.
+##' the session. The default is to not quit if running interactively.
 ##'
 ##' @param msg the message that should be printed.
 ##' @param ... any additional text that should be printed.

--- a/base/logger/man/logger.getLevel.Rd
+++ b/base/logger/man/logger.getLevel.Rd
@@ -7,10 +7,16 @@
 logger.getLevel()
 }
 \value{
-level the level of the message (ALL, DEBUG, INFO, WARN, ERROR, OFF)
+level the level of the message, one of
+"ALL", "DEBUG", "INFO", "WARN", "ERROR", "SEVERE", or "OFF".
 }
 \description{
-This will return the current level configured of the logging messages
+This will return the current level configured of the logging messages.
+}
+\details{
+Note that \code{logger.setLevel()} invisibly returns current level, so
+\code{logger.getLevel()} is not required to restore the level after a
+temporary change.
 }
 \examples{
 \dontrun{

--- a/base/logger/man/logger.setLevel.Rd
+++ b/base/logger/man/logger.setLevel.Rd
@@ -7,7 +7,10 @@
 logger.setLevel(level)
 }
 \arguments{
-\item{level}{the level of the message (ALL, DEBUG, INFO, WARN, ERROR, OFF)}
+\item{level}{the level of the message. One of "ALL", "DEBUG", "INFO", "WARN",
+"ERROR", "SEVERE", or "OFF".
+Use "SEVERE" instead of "ERROR" for fatal errors. If \code{logger.setQuitOnSevere(TRUE)},
+These will the program to stop (default is FALSE).}
 }
 \value{
 When logger level is set, the previous level is returned invisibly.
@@ -15,11 +18,16 @@ This can be passed to \code{logger.setLevel()} to restore the previous level.
 }
 \description{
 This will configure the logger level. This allows to turn DEBUG, INFO,
-WARN and ERROR messages on and off.
+WARN, ERROR, and SEVERE messages on and off.
 }
 \examples{
 \dontrun{
 logger.setLevel('DEBUG')
+
+# Temporarily turn logger off
+old_logger_level <- logger.setLevel("OFF")
+  # code here
+logger.setLevel(old_logger_level)
 }
 }
 \author{

--- a/base/logger/man/logger.severe.Rd
+++ b/base/logger/man/logger.severe.Rd
@@ -20,7 +20,7 @@ This function will print a message and stop execution of the code. This
 should only be used if the application should terminate.
 }
 \details{
-set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
+Set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
 the session. This is set by default to TRUE if interactive or running
 inside Rstudio.
 }


### PR DESCRIPTION
Written while reviewing of #3589

@infotroph please advise if you prefer I target this PR to pecan/develop instead of your PR.

## Summary

- Updates documentation to make sure SEVERE log level is consistently documented
- Fixes a bug in `logger.getLevelNumber` where ERROR and SEVERE were assigned the same value. I believe that this is why `logger.severe` does not stop workflows like it should.
- Clarifies that logger.setLevel should be used instead of logger.getLevel for temporary changes (since I realized during review of 3589 that setLevel returns the old level)

## Question for discussion

What is the desired behavior for SEVERE, and what is the desired default? 

My opinion: by default, `logger.severe` should stop execution and throw an error that can be caught in testing with `testthat::expect_error`.

Currently, the `logger.setQuitOnSevere` docs are unclear:

First, the default set at top of logger.R

```r
.utils.logger$quit <- FALSE
```

But the `logger.setQuitOnSevere` docs indicate that default is TRUE, although I don't fully understand the desired behavior when run interactively, inside Rstudio, or when scripted. And what makes Rstudio special? Is that just a shorthand for 'interactive' - would the same thing happen when run in Rstudio as a background job?

```r
##' set \code{\link{logger.setQuitOnSevere}(FALSE)} to avoid terminating
##' the session. This is set by default to TRUE if interactive or running
##' inside Rstudio.
```
